### PR TITLE
Added support for v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $sdk = \CarApiSdk\CarApi::build([
     'secret' => getenv('CARAPI_SECRET'),
     'httpVersion' => '2.0', // we recommend keeping the default 1.1
     'encoding' => ['gzip'],
+    'apiVersion' => 'v1' // the default is v2
 ]);
 ```
 

--- a/src/BaseApi.php
+++ b/src/BaseApi.php
@@ -18,6 +18,7 @@ class BaseApi
     protected StreamFactoryInterface $streamFactory;
     protected UriFactoryInterface $uriFactory;
     protected string $jwt;
+    protected string $apiVersion;
 
     /**
      * Construct
@@ -32,6 +33,7 @@ class BaseApi
         $this->host = ($config->host ?? 'https://carapi.app') . '/api';
         $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $this->uriFactory = Psr17FactoryDiscovery::findUriFactory();
+        $this->apiVersion = $config->apiVersion === 'v2' ? '/v2' : '';
     }
 
     /**

--- a/src/CarApi.php
+++ b/src/CarApi.php
@@ -13,6 +13,7 @@ class CarApi extends BaseApi
      * @param array $options See CarApiConfig for options
      *
      * @return self
+     * @throws CarApiException
      */
     public static function build(array $options): self
     {
@@ -29,7 +30,7 @@ class CarApi extends BaseApi
      */
     public function years(array $options = []): array
     {
-        return $this->getDecoded('/years', $options, true);
+        return $this->getDecoded('/years' . $this->apiVersion, $options, true);
     }
 
     /**
@@ -42,7 +43,7 @@ class CarApi extends BaseApi
      */
     public function makes(array $options = []): \stdClass
     {
-        return $this->getDecoded('/makes', $options);
+        return $this->getDecoded('/makes'  . $this->apiVersion, $options);
     }
 
     /**
@@ -55,7 +56,20 @@ class CarApi extends BaseApi
      */
     public function models(array $options = []): \stdClass
     {
-        return $this->getDecoded('/models', $options);
+        return $this->getDecoded('/models' . $this->apiVersion, $options);
+    }
+
+    /**
+     * Return vehicle submodels
+     *
+     * @param array $options An array of options to pass into the request.
+     *
+     * @return \stdClass
+     * @throws CarApiException
+     */
+    public function submodels(array $options = []): \stdClass
+    {
+        return $this->getDecoded('/submodels/v2', $options);
     }
 
     /**
@@ -68,7 +82,7 @@ class CarApi extends BaseApi
      */
     public function trims(array $options = []): \stdClass
     {
-        return $this->getDecoded('/trims', $options);
+        return $this->getDecoded('/trims' . $this->apiVersion, $options);
     }
 
     /**
@@ -81,7 +95,7 @@ class CarApi extends BaseApi
      */
     public function trimItem(int $id): \stdClass
     {
-        return $this->getDecoded(sprintf('/trims/%s', $id));
+        return $this->getDecoded(sprintf('/trims' . $this->apiVersion . '/%s', $id));
     }
 
     /**
@@ -157,7 +171,7 @@ class CarApi extends BaseApi
      */
     public function bodies(array $options = []): \stdClass
     {
-        return $this->getDecoded('/bodies', $options);
+        return $this->getDecoded('/bodies' . $this->apiVersion, $options);
     }
 
     /**
@@ -170,7 +184,7 @@ class CarApi extends BaseApi
      */
     public function engines(array $options = []): \stdClass
     {
-        return $this->getDecoded('/engines', $options);
+        return $this->getDecoded('/engines' . $this->apiVersion, $options);
     }
 
     /**
@@ -183,7 +197,7 @@ class CarApi extends BaseApi
      */
     public function mileages(array $options = []): \stdClass
     {
-        return $this->getDecoded('/mileages', $options);
+        return $this->getDecoded('/mileages' . $this->apiVersion, $options);
     }
 
     /**
@@ -196,7 +210,7 @@ class CarApi extends BaseApi
      */
     public function interiorColors(array $options = []): \stdClass
     {
-        return $this->getDecoded('/interior-colors', $options);
+        return $this->getDecoded('/interior-colors' . $this->apiVersion, $options);
     }
 
     /**
@@ -209,7 +223,7 @@ class CarApi extends BaseApi
      */
     public function exteriorColors(array $options = []): \stdClass
     {
-        return $this->getDecoded('/exterior-colors', $options);
+        return $this->getDecoded('/exterior-colors' . $this->apiVersion, $options);
     }
 
     /**

--- a/src/CarApiConfig.php
+++ b/src/CarApiConfig.php
@@ -22,6 +22,7 @@ class CarApiConfig
      * @param array       $encoding    Sets the accepts-encoding request header, default: []. To enable decoding
      *                                 set this option to ['gzip'] and ensure you have the gzip extension
      *                                 loaded.
+     * @param string      $apiVersion  The version of the API to make requests for.
      */
     public function __construct(
         string $token,
@@ -55,11 +56,13 @@ class CarApiConfig
 
         $validVersions = ['v1', 'v2'];
         if (isset($configs['apiVersion']) && !in_array($configs['apiVersion'], $validVersions)) {
-            throw new CarApiException(sprintf(
-                'Invalid API version. Must be one of (%s) but was given: %s',
-                implode(', ', $validVersions),
-                $configs['apiVersion']
-            ));
+            throw new CarApiException(
+                sprintf(
+                    'Invalid API version. Must be one of (%s) but was given: %s',
+                    implode(', ', $validVersions),
+                    $configs['apiVersion']
+                )
+            );
         }
 
         return new self(

--- a/src/CarApiConfig.php
+++ b/src/CarApiConfig.php
@@ -10,6 +10,7 @@ class CarApiConfig
     public ?string $host;
     public string $httpVersion;
     public array $encoding;
+    public string $apiVersion;
 
     /**
      * Constructor
@@ -27,13 +28,15 @@ class CarApiConfig
         string $secret,
         ?string $host = null,
         string $httpVersion = '1.1',
-        array $encoding = []
+        array $encoding = [],
+        string $apiVersion = 'v2'
     ) {
         $this->token = $token;
         $this->secret = $secret;
         $this->host = $host;
         $this->httpVersion = $httpVersion;
         $this->encoding = $encoding;
+        $this->apiVersion = $apiVersion;
     }
 
     /**
@@ -50,12 +53,22 @@ class CarApiConfig
             throw new CarApiException('Missing token and/or secret');
         }
 
+        $validVersions = ['v1', 'v2'];
+        if (isset($configs['apiVersion']) && !in_array($configs['apiVersion'], $validVersions)) {
+            throw new CarApiException(sprintf(
+                'Invalid API version. Must be one of (%s) but was given: %s',
+                implode(', ', $validVersions),
+                $configs['apiVersion']
+            ));
+        }
+
         return new self(
             $configs['token'],
             $configs['secret'],
             $configs['host'] ?? null,
             $configs['httpVersion'] ?? '1.1',
             $configs['encoding'] ?? [],
+            $configs['apiVersion'] ?? 'v2',
         );
     }
 }

--- a/test.php
+++ b/test.php
@@ -27,89 +27,91 @@ function println(string $string) {
     echo "\n\n$string\n\n";
 }
 
-$sdk = CarApi::build([
-    'token' => $env['TOKEN'],
-    'secret' => $env['SECRET'],
-    'host' => $env['HOST'],
-    'httpVersion' => '1.1',
-    'encoding' => ['gzip'],
-    'apiVersion' => 'v2',
-]);
+foreach (['v1', 'v2'] as $apiVersion) {
+    $sdk = CarApi::build([
+        'token' => $env['TOKEN'],
+        'secret' => $env['SECRET'],
+        'host' => $env['HOST'],
+        'httpVersion' => '1.1',
+        'encoding' => ['gzip'],
+        'apiVersion' => $apiVersion,
+    ]);
 
-println('JWT:' . $sdk->authenticate());
+    println('JWT:' . $sdk->authenticate());
 
-println('Years:');
-print_r($sdk->years(['query' => ['make' => 'Tesla']]));
+    println('Years:');
+    print_r($sdk->years(['query' => ['make' => 'Tesla']]));
 
-println('Makes:');
-print_r($sdk->makes(['query' => ['limit' => 1, 'page' => 0]]));
+    println('Makes:');
+    print_r($sdk->makes(['query' => ['limit' => 1, 'page' => 0]]));
 
-println('Models:');
-print_r($sdk->models(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Models:');
+    print_r($sdk->models(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('Trims:');
-$json = new JsonSearch();
-$json->addItem(new JsonSearchItem('make', 'like', 'Tesla'));
-print_r($sdk->trims(['query' => ['json' => $json, 'limit' => 1]]));
+    println('Trims:');
+    $json = new JsonSearch();
+    $json->addItem(new JsonSearchItem('make', 'like', 'Tesla'));
+    print_r($sdk->trims(['query' => ['json' => $json, 'limit' => 1]]));
 
-println('Trims:');
-print_r($sdk->trimItem(1));
+    println('Trims:');
+    print_r($sdk->trimItem(1));
 
-println('Bodies:');
-print_r($sdk->bodies(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Bodies:');
+    print_r($sdk->bodies(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('Engines:');
-print_r($sdk->engines(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Engines:');
+    print_r($sdk->engines(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('Mileages:');
-print_r($sdk->mileages(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Mileages:');
+    print_r($sdk->mileages(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('VIN:');
-print_r($sdk->vin('1GTG6CEN0L1139305'));
+    println('VIN:');
+    print_r($sdk->vin('1GTG6CEN0L1139305'));
 
-println('Interior Colors:');
-print_r($sdk->interiorColors(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Interior Colors:');
+    print_r($sdk->interiorColors(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('Exterior Colors:');
-print_r($sdk->exteriorColors(['query' => ['make' => 'Tesla', 'limit' => 1]]));
+    println('Exterior Colors:');
+    print_r($sdk->exteriorColors(['query' => ['make' => 'Tesla', 'limit' => 1]]));
 
-println('Vehicle Attributes:');
-print_r($sdk->vehicleAttributes('bodies.type'));
+    println('Vehicle Attributes:');
+    print_r($sdk->vehicleAttributes('bodies.type'));
 
-println('Account Requests:');
-print_r($sdk->accountRequests());
+    println('Account Requests:');
+    print_r($sdk->accountRequests());
 
-/*println('Account Requests Today:');
-print_r($sdk->accountRequestsToday());*/
+    /*println('Account Requests Today:');
+    print_r($sdk->accountRequestsToday());*/
 
-println('License Plate:');
-print_r($sdk->licensePlate('US', 'LNP8460#TEST', 'NY'));
+    println('License Plate:');
+    print_r($sdk->licensePlate('US', 'LNP8460#TEST', 'NY'));
 
-println('OBD Codes:');
-print_r($sdk->obdCodes(['query' => ['limit' => 1]]));
+    println('OBD Codes:');
+    print_r($sdk->obdCodes(['query' => ['limit' => 1]]));
 
-println('Single OBD Code:');
-print_r($sdk->obdCodeItem('B1200'));
+    println('Single OBD Code:');
+    print_r($sdk->obdCodeItem('B1200'));
 
-println('Done with Vehicles!');
+    println('Done with Vehicles!');
 
-$sdk = Powersports::build([
-    'token' => $env['TOKEN'],
-    'secret' => $env['SECRET'],
-    'host' => 'http://localhost:8080',
-    'httpVersion' => '1.1',
-    'encoding' => ['gzip'],
-]);
+    $sdk = Powersports::build([
+        'token' => $env['TOKEN'],
+        'secret' => $env['SECRET'],
+        'host' => 'http://localhost:8080',
+        'httpVersion' => '1.1',
+        'encoding' => ['gzip'],
+    ]);
 
-println('JWT:' . $sdk->authenticate());
+    println('JWT:' . $sdk->authenticate());
 
-println('Years:');
-print_r($sdk->years(['query' => ['make' => 'Honda', 'type' => 'street_motorcycle']]));
+    println('Years:');
+    print_r($sdk->years(['query' => ['make' => 'Honda', 'type' => 'street_motorcycle']]));
 
-println('Makes:');
-print_r($sdk->makes(['query' => ['limit' => 1, 'page' => 0, 'type' => 'street_motorcycle']]));
+    println('Makes:');
+    print_r($sdk->makes(['query' => ['limit' => 1, 'page' => 0, 'type' => 'street_motorcycle']]));
 
-println('Models:');
-print_r($sdk->models(['query' => ['make' => 'Honda', 'limit' => 1, 'type' => 'street_motorcycle']]));
+    println('Models:');
+    print_r($sdk->models(['query' => ['make' => 'Honda', 'limit' => 1, 'type' => 'street_motorcycle']]));
 
-println('Done with Powersports!');
+    println('Done with Powersports!');
+}

--- a/test.php
+++ b/test.php
@@ -33,6 +33,7 @@ $sdk = CarApi::build([
     'host' => $env['HOST'],
     'httpVersion' => '1.1',
     'encoding' => ['gzip'],
+    'apiVersion' => 'v2',
 ]);
 
 println('JWT:' . $sdk->authenticate());

--- a/tests/CarApiTest.php
+++ b/tests/CarApiTest.php
@@ -53,9 +53,54 @@ class CarApiTest extends TestCase
         $this->assertNotEmpty($arr);
     }
 
+    public function test_years_version_2(): void
+    {
+        $config = CarApiConfig::build(['token' => '1', 'secret' => '1', 'apiVersion' => 'v2']);
+        $client = $this->createMockClient(200, '["data"]');
+        $sdk = new CarApi($config, $client);
+        $arr = $sdk->years();
+        $this->assertNotEmpty($arr);
+    }
+
+    /**
+     * @dataProvider dataProviderForV2Methods
+     */
+    public function test_v2_methods_work(string $method): void
+    {
+        $config = CarApiConfig::build(['token' => '1', 'secret' => '1', 'apiVersion' => 'v2']);
+        $client = $this->createMockClient(200, '{"data": []}');
+        $sdk = new CarApi($config, $client);
+        $obj = $sdk->{$method}();
+        $this->assertObjectHasProperty('data', $obj);
+    }
+
+    public static function dataProviderForV2Methods(): array
+    {
+        return [
+            ['makes'],
+            ['models'],
+            ['submodels'],
+            ['trims'],
+            ['bodies'],
+            ['mileages'],
+            ['engines'],
+            ['interiorColors'],
+            ['exteriorColors'],
+        ];
+    }
+
     public function test_trim_item(): void
     {
         $config = CarApiConfig::build(['token' => '1', 'secret' => '1']);
+        $client = $this->createMockClient(200, '{"data": []}');
+        $sdk = new CarApi($config, $client);
+        $obj = $sdk->trimItem(1);
+        $this->assertObjectHasProperty('data', $obj);
+    }
+
+    public function test_trim_item_v2(): void
+    {
+        $config = CarApiConfig::build(['token' => '1', 'secret' => '1', 'apiVersion' => 'v2']);
         $client = $this->createMockClient(200, '{"data": []}');
         $sdk = new CarApi($config, $client);
         $obj = $sdk->trimItem(1);


### PR DESCRIPTION
Added support for new v2 endpoints: https://carapi.app/api

Uses who are upgrading from version 1 the SDK to version 2 of the SDK but staying on version 1 of the API will need to tell the SDK client to make requests to the v1 api:

```php
$sdk = \CarApiSdk\CarApi::build([
    'token' => getenv('CARAPI_TOKEN'),
    'secret' => getenv('CARAPI_SECRET'),
    'apiVersion' => 'v1' // <------ the default is v2
]);
```